### PR TITLE
 windows: Do not explicitly link ntdll.dll and msvcrt.dll

### DIFF
--- a/wx/setup_windows_386.go
+++ b/wx/setup_windows_386.go
@@ -4,6 +4,7 @@ package wx
 // #cgo !wxgo_binary_package_build LDFLAGS: -L${SRCDIR}/windows_386/lib -lwxmsw31u -lwxmsw31u_gl -lwxregexu -lwxexpat -lwxtiff -lwxjpeg -lwxpng -lwxzlib -lwxscintilla
 // #cgo mingw_workaround LDFLAGS: -Wl,--subsystem,windows,--allow-multiple-definition
 // #cgo !mingw_workaround LDFLAGS: -Wl,--subsystem,windows
-// #cgo LDFLAGS: -l:libstdc++.a -mwindows -lopengl32 -lglu32 -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lshlwapi -lcomctl32 -lcomdlg32 -ladvapi32 -lversion -lwsock32 -lgdi32 -lntdll -lmsvcrt
+// #cgo LDFLAGS: -l:libstdc++.a -mwindows -lopengl32 -lglu32 -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lshlwapi -lcomctl32 -lcomdlg32 -ladvapi32 -lversion -lwsock32 -lgdi32
+// #cgo !go1.8 LDFLAGS: -lntdll -lmsvcrt
 // #cgo CXXFLAGS: -fpermissive
 import "C"

--- a/wx/setup_windows_amd64.go
+++ b/wx/setup_windows_amd64.go
@@ -4,6 +4,7 @@ package wx
 // #cgo !wxgo_binary_package_build LDFLAGS: -L${SRCDIR}/windows_amd64/lib -lwxmsw31u -lwxmsw31u_gl -lwxscintilla -lwxregexu -lwxexpat -lwxtiff -lwxjpeg -lwxpng -lwxzlib
 // #cgo mingw_workaround LDFLAGS: -Wl,--subsystem,windows,--allow-multiple-definition
 // #cgo !mingw_workaround LDFLAGS: -Wl,--subsystem,windows
-// #cgo LDFLAGS: -l:libstdc++.a -mwindows -lopengl32 -lglu32 -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lshlwapi -lcomctl32 -lcomdlg32 -ladvapi32 -lversion -lwsock32 -lgdi32 -lntdll -lmsvcrt
+// #cgo LDFLAGS: -l:libstdc++.a -mwindows -lopengl32 -lglu32 -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lshlwapi -lcomctl32 -lcomdlg32 -ladvapi32 -lversion -lwsock32 -lgdi32
+// #cgo !go1.8 LDFLAGS: -lntdll -lmsvcrt
 // #cgo CXXFLAGS: -fpermissive
 import "C"


### PR DESCRIPTION
Linking ntdll.dll has unexpected side effects.
See: https://github.com/golang/go/issues/12030

Starting from Go 1.8, it is not necessary to link ntdll.dll and
msvcrt.dll explicitly.  Link them explicitly only for < 1.8.
See: https://golang.org/cl/30737
